### PR TITLE
Update evt.reply to use 'allow_html' + bump ver

### DIFF
--- a/giphy.py
+++ b/giphy.py
@@ -54,4 +54,4 @@ class GiphyPlugin(Plugin):
             gif_link = gif.get("url")
 
         if gif_exists:
-            await evt.reply(gif_link, html_in_markdown=True)  # Reply to user
+            await evt.reply(gif_link, allow_html=True)  # Reply to user

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: casavant.tom.giphy
 
 # A PEP 440 compliant version string.
-version: 1.0.3
+version: 1.0.4
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.


### PR DESCRIPTION
This PR fixes an error due to change in API upstream: `reply()` arg `html_in_markdown` was changed to `allow_html` in maubot recently.

https://github.com/maubot/maubot/commit/1d03fd83df88c3b271b9fe0b638384b105796258