### PR TITLE
Clean up code a bit, and introduce upload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ A simple [maubot](https://github.com/maubot/maubot) that generates a random gif 
 1. Get API key from [giphy](https://developers.giphy.com/docs/)
 2. Fill in api_key field in base-config.yaml config file or in online maubot config editor
 3. Decide what endpoint to get random gifs from (e.g. trending, random) in config file
+4. Choose a response type:
+  - message will send a regular message to the room
+  - reply will send a quoted reply message to the room
+  - upload will actually upload the GIF as an image to the room
+
 
 ## Usage
 '!giphy word' - Bot replies with a link to a gif given the search term

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -1,7 +1,10 @@
 api_key: API_KEY_HERE
 #Uncomment desired source for random gifs
+# can be either trending or random
+# note: this is only used when no query is passed!
 source: trending
-#source: random
-#Uncomment desired response type, either a quoted reply or just a new message
+# desired response type:
+#   message: regular message containing url to gif
+#   reply: reply-message containing url to gif
+#   upload: image upload to the room
 response_type: message
-#response_type: reply

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: casavant.tom.giphy
 
 # A PEP 440 compliant version string.
-version: 1.0.5
+version: 1.1.2
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.


### PR DESCRIPTION
I plan on keeping my fork updated with any other new features, so don't feel like you need to merge this in, but I thought I would throw it your way since you wrote the original code!

big change here is the introduction of an "upload" message type, which will upload the image directly to the room rather than just responding with a url. file uploads are titled as whatever the query to giphy was, or just `giphy.gif` if no query was supplied:

![Screenshot_20201210154247](https://user-images.githubusercontent.com/8409433/101843144-6bd29880-3afe-11eb-8d1c-67f13e6333aa.png)


that change also included changes to the code to use the url directly to the `.gif` file instead of the general giphy page, so this eliminates additional text from giphy.com in the link preview widgets.
![Screenshot_20201210154440](https://user-images.githubusercontent.com/8409433/101843255-a9372600-3afe-11eb-9b1c-b625a46366d1.png)
