### PR TITLE
Add MPAA-like content rating functionality

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -15,7 +15,8 @@ source: trending
 #   reply: reply-message containing url to gif
 #   upload: image upload to the room
 response_type: message
-# (Giphy only) Choose an MPAA-like content "rating", 'g' 
-# is default (g|pg|pg-13|r) 
-# https://developers.giphy.com/docs/optional-settings/#rating
-rating: g
+# Choose an MPAA-like content "rating" 
+#   Giphy values: [g | pg | pg-13 | r] 
+#   Tenor values: [high | medium | low | off]
+#   default values: 'g' for Giphy, 'off' for Tenor
+rating: off

--- a/base-config.yaml
+++ b/base-config.yaml
@@ -15,3 +15,7 @@ source: trending
 #   reply: reply-message containing url to gif
 #   upload: image upload to the room
 response_type: message
+# (Giphy only) Choose an MPAA-like content "rating", 'g' 
+# is default (g|pg|pg-13|r) 
+# https://developers.giphy.com/docs/optional-settings/#rating
+rating: g

--- a/giphy.py
+++ b/giphy.py
@@ -16,6 +16,7 @@ class Config(BaseProxyConfig):
         helper.copy("source")
         helper.copy("response_type")
         helper.copy("num_results")
+        helper.copy("rating")
 
 
 class GiphyPlugin(Plugin):
@@ -65,7 +66,7 @@ class GiphyPlugin(Plugin):
 
         if self.config["provider"] == "giphy":
             api_key = self.config["giphy_api_key"]
-            url_params = urllib.parse.urlencode({"s": search_term, "api_key": api_key})
+            url_params = urllib.parse.urlencode({"s": search_term, "api_key": api_key, "rating": rating})
             response_type = self.config["response_type"]
             # Get random gif url using search term
             async with self.http.get(

--- a/giphy.py
+++ b/giphy.py
@@ -66,6 +66,7 @@ class GiphyPlugin(Plugin):
 
         if self.config["provider"] == "giphy":
             api_key = self.config["giphy_api_key"]
+            rating = self.config["rating"]
             url_params = urllib.parse.urlencode({"s": search_term, "api_key": api_key, "rating": rating})
             response_type = self.config["response_type"]
             # Get random gif url using search term
@@ -87,6 +88,7 @@ class GiphyPlugin(Plugin):
 
         elif self.config["provider"] == "tenor":
             api_key = self.config["tenor_api_key"]
+            rating = self.config["rating"]
             url_params = urllib.parse.urlencode({"q": search_term, "key": api_key, "contentfilter": rating})
             response_type = self.config["response_type"]
             # Get random gif url using search term

--- a/giphy.py
+++ b/giphy.py
@@ -87,7 +87,7 @@ class GiphyPlugin(Plugin):
 
         elif self.config["provider"] == "tenor":
             api_key = self.config["tenor_api_key"]
-            url_params = urllib.parse.urlencode({"q": search_term, "key": api_key})
+            url_params = urllib.parse.urlencode({"q": search_term, "key": api_key, "contentfilter": rating})
             response_type = self.config["response_type"]
             # Get random gif url using search term
             async with self.http.get(


### PR DESCRIPTION
I've noticed Tenor and Giphy do not always return the same gifs for the same searches in different clients, and discovered that they do actually have content rating API endpoints. 

https://tenor.com/gifapi/documentation#contentfilter
https://support.giphy.com/hc/en-us/articles/360058840971-Content-Rating

These small changes should allow/deny content based on the rating specified.

I can confirm this works for both Giphy and Tenor after building and uploading the bot to my maubot instance.