### PR TITLE
Use Tenor API v2 by default

### DIFF
--- a/base-config.yaml
+++ b/base-config.yaml
@@ -1,5 +1,7 @@
 giphy_api_key: API_KEY_HERE
 tenor_api_key: API_KEY_HERE
+# Which Tenor API version to use: v1 or v2?
+tenor_api_version: v2
 # Source of the gifs, can be either giphy or tenor
 provider: tenor
 # Number of results of the query in which the gif
@@ -15,8 +17,8 @@ source: trending
 #   reply: reply-message containing url to gif
 #   upload: image upload to the room
 response_type: message
-# Choose an MPAA-like content "rating" 
-#   Giphy values: [g | pg | pg-13 | r] 
+# Choose an MPAA-like content "rating"
+#   Giphy values: [g | pg | pg-13 | r]
 #   Tenor values: [high | medium | low | off]
 #   default values: 'g' for Giphy, 'off' for Tenor
 rating: off

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: casavant.tom.giphy
 
 # A PEP 440 compliant version string.
-version: 3.0.1
+version: 3.2.0
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.


### PR DESCRIPTION
It is no longer possible to register new keys for API v1 on <https://tenor.com/developer/keyregistration>:

> V1 API Key registration is no longer supported.

Therefore GIF bot was updated to add a configurable API version. `v2` is used by default, but users with API v1 keys can switch to `v1`.