### PR TITLE
Fix media format retrieval for API v1

### DIFF
--- a/giphy.py
+++ b/giphy.py
@@ -102,7 +102,11 @@ class GiphyPlugin(Plugin):
             # Retrieve gif link from JSON response
             try:
                 image_num = random.randint(0, self.config["num_results"] - 1)
-                gif = data["results"][image_num]["media_formats"]["gif"]
+                result = data["results"][image_num]
+                gif = (
+                    result["media_formats"] if api_version == "v2"
+                    else result["media"][0]
+                )["gif"]
                 gif_link = gif["url"]
                 info = {}
                 info["width"] = gif["dims"][0]

--- a/maubot.yaml
+++ b/maubot.yaml
@@ -9,7 +9,7 @@ maubot: 0.1.0
 id: casavant.tom.giphy
 
 # A PEP 440 compliant version string.
-version: 3.2.0
+version: 3.2.1
 
 # The SPDX license identifier for the plugin. https://spdx.org/licenses/
 # Optional, assumes all rights reserved if omitted.


### PR DESCRIPTION
After the commit's 17258a1 (#9) changes it was not possible to retrieve information about GIF for Tenor API v1 as JSON structure in the v2 response is a bit different.